### PR TITLE
fix: adapt template to tera v2 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### 🐞 Bug fixes
+- Use named arguments in template filters/tests and preserve dependency ordering for compatibility with `tera` v2.
+
 ## v1.0.3 - 2026-05-15
 
 ### ⛓️ Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### 🐞 Bug fixes
+### bugfix
 - Use named arguments in template filters/tests and preserve dependency ordering for compatibility with `tera` v2.
 
 ## v1.0.3 - 2026-05-15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +271,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -515,6 +537,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
 dependencies = [
+ "indexmap",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 clap = { version = "4.6.1", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-tera = "2.0.0"
+tera = { version = "2.0.0", features = ["preserve_order"] }
 thiserror = "2.0.18"
 
 [dev-dependencies]

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -76,12 +76,33 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
+## equivalent <https://crates.io/crates/equivalent>
+
+Distributed under the following license(s):
+
+* Apache-2.0
+* MIT
+
+## hashbrown <https://crates.io/crates/hashbrown>
+
+Distributed under the following license(s):
+
+* MIT
+* Apache-2.0
+
 ## heck <https://crates.io/crates/heck>
 
 Distributed under the following license(s):
 
 * MIT
 * Apache-2.0
+
+## indexmap <https://crates.io/crates/indexmap>
+
+Distributed under the following license(s):
+
+* Apache-2.0
+* MIT
 
 ## is_terminal_polyfill <https://crates.io/crates/is_terminal_polyfill>
 

--- a/THIRD_PARTY_NOTICES.md.tmpl
+++ b/THIRD_PARTY_NOTICES.md.tmpl
@@ -6,7 +6,7 @@ In the event that a required notice is missing or incorrect, please notify us ei
 
 For any licenses that require the disclosure of source code, the source code can be found at <https://github.com/newrelic/rust-licenses-noticer>.
 {% for dep, licenseObj in dependencies %}
-{%- if dep is containing("rust-licenses-noticer") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="rust-licenses-noticer") %}{% continue %}{% endif %}
 ## {{ dep | split(pat=" ") | first }} <{{ dep | split(pat=" ") | last }}>
 
 Distributed under the following license(s):

--- a/src/cargo_deny_list.rs
+++ b/src/cargo_deny_list.rs
@@ -21,7 +21,7 @@
 //!
 //! This module parses this JSON object into a more usable format for our use case.
 //! See [CargoDenyList] type for more information.
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -47,7 +47,13 @@ use serde::{Deserialize, Deserializer, Serialize};
 #[derive(Debug, Serialize, PartialEq)]
 pub(super) struct CargoDenyList {
     /// Map of dependencies and their licenses.
-    dependencies: HashMap<NameAndUrl, LicenseList>,
+    ///
+    /// This is intentionally a [BTreeMap] (not a [HashMap](std::collections::HashMap)): it keeps
+    /// dependencies sorted by key so the generated notices file has a stable, alphabetical order.
+    /// `tera` is built with the `preserve_order` feature so it renders this map in iteration order
+    /// rather than sorting itself (tera v1 sorted map keys on iteration; v2 does not). Do not swap
+    /// this for an unordered map or the output ordering becomes non-deterministic.
+    dependencies: BTreeMap<NameAndUrl, LicenseList>,
 }
 
 impl<'de> Deserialize<'de> for CargoDenyList {
@@ -56,7 +62,7 @@ impl<'de> Deserialize<'de> for CargoDenyList {
         D: Deserializer<'de>,
     {
         Ok(CargoDenyList {
-            dependencies: HashMap::deserialize(deserializer)?,
+            dependencies: BTreeMap::deserialize(deserializer)?,
         })
     }
 }
@@ -81,7 +87,7 @@ struct LicenseList {
 /// ```
 ///
 /// The URL is formatted as a link to the dependency's page.
-#[derive(Debug, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 struct NameAndUrl(String);
 
 impl<'de> Deserialize<'de> for NameAndUrl {

--- a/tests/golden/fixtures/THIRD_PARTY_NOTICES.md.tmpl
+++ b/tests/golden/fixtures/THIRD_PARTY_NOTICES.md.tmpl
@@ -13,12 +13,12 @@ For any licenses that require the disclosure of source code, the source code
 can be found at https://github.com/newrelic/newrelic-oauth-client-rs.
 
 {% for dep, licenseObj in dependencies %}
-{%- if dep is containing("newrelic_agent_control") %}{% continue %}{% endif -%}
-{%- if dep is containing("resource-detection") %}{% continue %}{% endif -%}
-{%- if dep is containing("fs") %}{% continue %}{% endif -%}
-{%- if dep is containing("nr-auth") %}{% continue %}{% endif -%}
-{%- if dep is containing("license") %}{% continue %}{% endif -%}
-{%- if dep is containing("config-migrate") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="newrelic_agent_control") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="resource-detection") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="fs") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="nr-auth") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="license") %}{% continue %}{% endif -%}
+{%- if dep is containing(pat="config-migrate") %}{% continue %}{% endif -%}
 ## {{ dep | split(pat=" ") | first }} {{ dep | split(pat=" ") | last | replace(from="registry+https://github.com/rust-lang/crates.io-index", to="https://crates.io/crates/" ~ dep | split(pat=" ") | first ) }}
 
 Distributed under the following license(s):


### PR DESCRIPTION
## Summary

The upgrade to `tera` v2 (#83) broke template rendering. This adapts the templates and the data model to v2's behavior; the golden test now passes again.

## Why it broke

tera v1 → v2 introduced two breaking changes that the golden test exercised:

1. **Test arguments must now be named (keyword) rather than positional.** The templates used `dep is containing("…")`. In v2 the `containing` test reads its pattern from a kwarg named `pat`, so the positional string was rejected with `Found string but expected identifier`.
2. **Map iteration order changed.** tera v1 *sorted* object keys when iterating in a `{% for %}` loop, so the notices file came out alphabetical. v2 no longer sorts — by default it uses an unordered map, producing non-deterministic order.

## Changes

- Templates (`THIRD_PARTY_NOTICES.md.tmpl` and the test fixture): `containing("…")` → `containing(pat="…")`.
- `Cargo.toml`: enable tera's `preserve_order` feature so it renders maps in iteration order instead of randomizing.
- `src/cargo_deny_list.rs`: switch `dependencies` from `HashMap` to `BTreeMap` (adding `PartialOrd, Ord` to the `NameAndUrl` key) as the deterministic, alphabetical source of ordering, with a comment explaining why.

## Test plan

- `cargo test` — all unit, golden, and doctests pass.
- `cargo clippy --all-targets` — clean.