### PR TITLE
ci: skip tag pushes in third party licenses check

### DIFF
--- a/.github/workflows/third_party_licenses_check.yml
+++ b/.github/workflows/third_party_licenses_check.yml
@@ -2,6 +2,12 @@ permissions:
   contents: read
 on:
   push:
+    # This check dogfoods the action by installing the noticer from the pushed
+    # ref via `cargo install --branch ${{ github.ref_name }}`. On a tag push
+    # (e.g. the moving `v1` tag updated during a release) that ref is a tag, not
+    # a branch, so the install fails with "failed to find branch". Skip tags.
+    tags-ignore:
+      - "**"
 # See https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary

Fixes the failing [⚖️ Third party licenses](https://github.com/newrelic/rust-licenses-noticer/actions/runs/28367502380/job/84039414974) run that errored with `error: failed to find branch v1`.

## Root cause

The `third_party_licenses_check.yml` workflow dogfoods this action against the repo itself. The action installs the noticer from the pushed ref:

```yaml
rust-licenses-noticer-branch: ${{ github.ref_name }}
```

```sh
cargo install --git ... --branch ${{ inputs.rust-licenses-noticer-branch }}
```

The workflow triggers on **every** push, including tags. When the moving `v1` tag is updated during a release, the resulting tag push fires the workflow with `github.ref_name=v1`. The action then runs `cargo install --branch v1`, which fails because `v1` is a **tag**, not a branch:

```
error: failed to find branch `v1`
```

## Fix

Restrict the trigger to branch pushes by ignoring all tags (`tags-ignore: ["**"]`). Branch-push behavior is unchanged; tag pushes (which only re-point to already-checked commits) no longer run this check.